### PR TITLE
Revert "Fix for the prior posterior plot incorrectly switching the bf10 and bf01 label"

### DIFF
--- a/R/commonsummarystatsttestbayesian.R
+++ b/R/commonsummarystatsttestbayesian.R
@@ -338,12 +338,12 @@
     ttestTableMessage  <- NULL
   }
 
- # Add BF10 or BF01 label for plots; never show the log Bayes factor in the plots (it interferes with the pie charts)
-  if (options$bayesFactorType == "BF01")
-    bfPlotsH1H0 <- FALSE
-   else 
-    bfPlotsH1H0 <- TRUE
-
+  # Add information for plots; never show the log Bayes factor in the plots (it interferes with the pie charts)
+  if(options$bayesFactorType == "BF01"){
+    BFPlots <- "BF01"
+  } else {
+    BFPlots <- "BF10"
+  }
 
   ttestPriorPosteriorPlot <- list(
     t        = t,
@@ -351,8 +351,8 @@
     n2       = NULL,
     paired   = TRUE,
     oneSided = hypothesisList$oneSided,
-    BF       = BFlist[["BF10"]],
-    BFH1H0   = bfPlotsH1H0
+    BF       = BFlist[[BFPlots]],
+    BFH1H0   = BFlist[["BF10"]]
   )
 
   ttestRobustnessPlot <- list(
@@ -361,7 +361,7 @@
     n2                        = 0 ,
     paired                    = FALSE,
     BF10user                  = BFlist[["BF10"]],
-    yAxisLegendRobustnessPlot = bfPlotsH1H0,
+    yAxisLegendRobustnessPlot = BFPlots,
     nullInterval              = hypothesisList$nullInterval,
     rscale                    = options$priorWidth,
     oneSided                  = hypothesisList$oneSided


### PR DESCRIPTION
Reverts jasp-stats/jaspSummaryStatistics#3

Unit test: Comment by Akash

https://github.com/jasp-stats/jasp-desktop/pull/4254#pullrequestreview-477591503