### PR TITLE
Bugfix: jaspTTests package was not specified when .bf10_normal() was called

### DIFF
--- a/R/commonsummarystatsttestbayesian.R
+++ b/R/commonsummarystatsttestbayesian.R
@@ -150,7 +150,7 @@
       bf <- bfObject$bf
       error <- 100*bfObject$error
     } else if (options[["informativeStandardizedEffectSize"]] == "normal") {
-      bf <- .bf10_normal(t = tValue, n1 = n1, n2 = n2, oneSided = side,
+      bf <- jaspTTests::.bf10_normal(t = tValue, n1 = n1, n2 = n2, oneSided = side,
                          independentSamples = !paired,
                          prior.mean = options[["informativeNormalMean"]],
                          prior.variance = options[["informativeNormalStd"]]^2)

--- a/tests/testthat/test-summarystatsttestbayesianindependentsamples.R
+++ b/tests/testthat/test-summarystatsttestbayesianindependentsamples.R
@@ -80,21 +80,25 @@ test_that("BF Type Label Switches Correctly Prior Posterior", {
 
 test_that("Informed priors work", {
   options <- analysisOptions("SummaryStatsTTestBayesianIndependentSamples")
-  options$n1Size <- 20
-  options$n2Size <- 20
+
+  options$n1Size     <- 20
+  options$n2Size     <- 20
   options$tStatistic <- 2
+  options$effectSizeStandardized <- "informative"
 
   reference <- list(
     t      = list(1.45400012678284, 0.000123486895286172, 20, 20, 0.0526850709676671, 2),
     normal = list(2.04756225232945, "NaN", 20, 20, 0.0526850709676671, 2)
   )
 
-  for (informativeStandardizedEffectSize in c("normal", "t"))
+  for (informativeStandardizedEffectSize in c("normal", "t")) {
 
-  options$informativeStandardizedEffectSize <- informativeStandardizedEffectSize
-  set.seed(1)
-  results <- runAnalysis("SummaryStatsTTestBayesianIndependentSamples", NULL, options)
-  table <- results[["results"]][["ttestContainer"]][["collection"]][["ttestContainer_ttestTable"]][["data"]]
-  jaspTools::expect_equal_tables(table, reference[[informativeStandardizedEffectSize]])
+    options$informativeStandardizedEffectSize <- informativeStandardizedEffectSize
+    set.seed(1)
+    results <- runAnalysis("SummaryStatsTTestBayesianIndependentSamples", NULL, options)
+    table <- results[["results"]][["ttestContainer"]][["collection"]][["ttestContainer_ttestTable"]][["data"]]
+    jaspTools::expect_equal_tables(table, reference[[informativeStandardizedEffectSize]])
+
+  }
 
 })

--- a/tests/testthat/test-summarystatsttestbayesianindependentsamples.R
+++ b/tests/testthat/test-summarystatsttestbayesianindependentsamples.R
@@ -78,4 +78,23 @@ test_that("BF Type Label Switches Correctly Prior Posterior", {
   jaspTools::expect_equal_plots(testPlot, "prior-and-posterior-3")
 })
 
+test_that("Informed priors work", {
+  options <- analysisOptions("SummaryStatsTTestBayesianIndependentSamples")
+  options$n1Size <- 20
+  options$n2Size <- 20
+  options$tStatistic <- 2
 
+  reference <- list(
+    t      = list(1.45400012678284, 0.000123486895286172, 20, 20, 0.0526850709676671, 2),
+    normal = list(2.04756225232945, "NaN", 20, 20, 0.0526850709676671, 2)
+  )
+
+  for (informativeStandardizedEffectSize in c("normal", "t"))
+
+  options$informativeStandardizedEffectSize <- informativeStandardizedEffectSize
+  set.seed(1)
+  results <- runAnalysis("SummaryStatsTTestBayesianIndependentSamples", NULL, options)
+  table <- results[["results"]][["ttestContainer"]][["collection"]][["ttestContainer_ttestTable"]][["data"]]
+  jaspTools::expect_equal_tables(table, reference[[informativeStandardizedEffectSize]])
+
+})


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release#1223 
Fixes jasp-stats/jasp-test-release#1225
Fixes jasp-stats/jasp-test-release#1226

Supersedes https://github.com/jasp-stats/jaspSummaryStatistics/pull/18

the export in jaspTTests was added in https://github.com/jasp-stats/jaspTTests/pull/61