### PR TITLE
use reuseable workflow

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,36 +1,18 @@
-on: [push, pull_request]
+on:
+  push:
+    paths: ['**.R', 'tests/**', '**.Rd', '**.c', '**.cpp', '**.h', '**.hpp', 'DESCRIPTION', 'NAMESPACE', 'MAKEVARS', 'MAKEVARS.win', '**.yml']
+  pull_request:
+    paths: ['**.R', 'tests/**', '**.Rd', '**.c', '**.cpp', '**.h', '**.hpp', 'DESCRIPTION', 'NAMESPACE', 'MAKEVARS', 'MAKEVARS.win']
+  schedule:
+    - cron:  '13 12 * * 1-5'
 
 name: unit-tests
 
 jobs:
+
   unit-tests:
-    runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: windows-latest, r: "4.1.0"}
-          - {os: macOS-latest,   r: "4.1.0"}
-          - {os: ubuntu-20.04,   r: "4.1.0"}
-
-    env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      R_REMOTES_UPGRADE: never
-      VDIFFR_RUN_TESTS: true
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@master
-        with:
-          r-version: ${{ matrix.config.r }}
-
-      - uses: jasp-stats/jasp-actions/setup-test-env@master
-
-      - name: Run unit tests
-        run: source("tests/testthat.R")
-        shell: Rscript {0}
+    uses: jasp-stats/jasp-actions/.github/workflows/unittests.yml@master
+    with:
+      needs_JAGS:   false
+      needs_igraph: false


### PR DESCRIPTION
The tests fail because jaspRegresion cannot be installed since BAS was removed from CRAN: https://github.com/vandenman/jaspSummaryStatistics/runs/6140856814?check_suite_focus=true#step:14:1657

update: tests pass now that BAS is back on CRAN: https://github.com/vandenman/jaspSummaryStatistics/actions/runs/2212680399